### PR TITLE
Add compose email infrastructure and provider send adapters

### DIFF
--- a/docs/SECOND_LIST_OF_CHANGES.md
+++ b/docs/SECOND_LIST_OF_CHANGES.md
@@ -1,0 +1,47 @@
+# Second List of Changes — Item #3
+
+## Compose New Email (Contacts, Provider Selection, LLM First-Draft)
+
+### 0) Objective
+Describe new feature enabling composing brand-new emails from Telegram with provider and contact selection, automatic LLM draft generation, and recording sent messages.
+
+### 1) Scope
+- Telegram Compose flow for provider, recipients, subject, body and approval.
+- Local contacts lookup with ranking.
+- Provider-agnostic send pipeline using adapters.
+- Database support for outbound messages and draft revisions.
+
+### 2) User Stories
+- **US-CMP-01**: Start compose, choose provider, recipients, first draft auto generated.
+- **US-CMP-02**: Search contacts and add To/CC/BCC.
+- **US-CMP-03**: After sending, confirmation and view thread option.
+
+### 3) Functional Requirements
+- **FR-1**: Compose entry points via button and `/compose` command.
+- **FR-2**: Recipient picking with search, manual email entry and CC/BCC.
+- **FR-3**: Subject and body prompting with LLM first draft, approve/edit/regenerate.
+- **FR-4**: Send semantics capturing provider ids and storing outbound info.
+- **FR-5**: Contacts sourced from local messages with frequency ranking.
+
+### 4) Non-Functional Requirements
+- Minimal Telegram UX steps, email validation, provider retry/backoff and isolated adapters.
+
+### 5) Data Model (PostgreSQL)
+Includes `contacts` table and outbound fields (`direction`, recipient arrays) on `email_messages`.
+
+### 6) Provider Adapters
+- `gmail_send_message` – encode RFC-2822 message and send via Gmail API.
+- `outlook_send_mail` – send via Microsoft Graph `/me/sendMail` endpoint.
+
+### 7) Repository & Service Code
+- `contacts_repo.search_contacts(q)` for ranked lookups.
+- `email_repo.create_outbound_draft(...)` and `mark_outbound_sent(...)` for state.
+
+### 8) Telegram Flow
+State machine steps: provider → recipients → subject → draft (LLM) → approve/send.
+
+### 9) Best Practices
+Always draft first, validate emails, respect rate limits and privacy, and maintain logging and idempotency.
+
+### 10) Acceptance Tests
+Outlined tests cover compose basics, CC/BCC, search, draft editing, provider paths, validation and resilience.

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,19 @@
+"""Simple PostgreSQL connection helper."""
+from __future__ import annotations
+
+import os
+import psycopg
+from typing import Any
+
+
+def get_conn() -> psycopg.Connection[Any]:
+    """Return a new database connection.
+
+    The connection parameters are read from the ``DATABASE_URL`` environment
+    variable. This helper centralizes access so modules can share the same
+    configuration without repeating boilerplate.
+    """
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+    return psycopg.connect(dsn)

--- a/src/pa_v2/__init__.py
+++ b/src/pa_v2/__init__.py
@@ -1,0 +1,14 @@
+"""Compatibility package exposing the public API for PA_V2.
+
+This repository originally used a flat ``src/`` layout.  Some tests expect the
+package to be importable as ``pa_v2`` so we provide lightweight wrappers that
+re-export the existing modules.
+"""
+
+from .email_system.integration import send_email, get_latest_emails, EmailProviderRegistry
+
+__all__ = [
+    "send_email",
+    "get_latest_emails",
+    "EmailProviderRegistry",
+]

--- a/src/pa_v2/email_system/__init__.py
+++ b/src/pa_v2/email_system/__init__.py
@@ -1,0 +1,3 @@
+"""Wrapper package providing access to email system modules."""
+
+from email_system.integration import *  # noqa: F401,F403

--- a/src/pa_v2/email_system/integration.py
+++ b/src/pa_v2/email_system/integration.py
@@ -1,0 +1,2 @@
+"""Compatibility wrapper for the integration module."""
+from email_system.integration import *  # noqa: F401,F403

--- a/src/pa_v2/email_system/providers/__init__.py
+++ b/src/pa_v2/email_system/providers/__init__.py
@@ -1,0 +1,7 @@
+"""Re-export provider implementations for compatibility."""
+
+from email_system.providers.dummy_provider import DummyProvider  # noqa: F401
+from email_system.providers.gmail_provider import GmailProvider  # noqa: F401
+from email_system.providers.outlook_provider import OutlookGraphProvider  # noqa: F401
+
+__all__ = ["DummyProvider", "GmailProvider", "OutlookGraphProvider"]

--- a/src/pa_v2/email_system/providers/dummy_provider.py
+++ b/src/pa_v2/email_system/providers/dummy_provider.py
@@ -1,0 +1,1 @@
+from email_system.providers.dummy_provider import *  # noqa: F401,F403

--- a/src/pa_v2/email_system/providers/gmail_provider.py
+++ b/src/pa_v2/email_system/providers/gmail_provider.py
@@ -1,0 +1,1 @@
+from email_system.providers.gmail_provider import *  # noqa: F401,F403

--- a/src/pa_v2/email_system/providers/outlook_provider.py
+++ b/src/pa_v2/email_system/providers/outlook_provider.py
@@ -1,0 +1,1 @@
+from email_system.providers.outlook_provider import *  # noqa: F401,F403

--- a/src/providers/gmail_send.py
+++ b/src/providers/gmail_send.py
@@ -1,0 +1,57 @@
+import base64
+from email.message import EmailMessage
+from typing import List, Optional, Dict
+
+
+def gmail_send_message(
+    service,
+    from_addr: str,
+    to: List[str],
+    cc: List[str],
+    bcc: List[str],
+    subject: str,
+    body_text: str,
+    body_html: Optional[str] = None,
+) -> Dict:
+    """Send an email using the Gmail API.
+
+    Parameters
+    ----------
+    service:
+        Authenticated Gmail service instance.
+    from_addr:
+        Sender email address.
+    to, cc, bcc:
+        Recipient lists. Empty lists are ignored.
+    subject:
+        Email subject line.
+    body_text:
+        Plain text body of the message.
+    body_html:
+        Optional HTML body. When provided a multipart/alternative message is
+        created with the text version first followed by the HTML part.
+
+    Returns
+    -------
+    dict
+        The Gmail API response containing at least an ``id`` and ``threadId``.
+    """
+
+    msg = EmailMessage()
+    msg["From"] = from_addr
+    msg["To"] = ", ".join(to)
+    if cc:
+        msg["Cc"] = ", ".join(cc)
+    if bcc:
+        msg["Bcc"] = ", ".join(bcc)
+    msg["Subject"] = subject
+
+    if body_html:
+        msg.set_content(body_text or "")
+        msg.add_alternative(body_html, subtype="html")
+    else:
+        msg.set_content(body_text or "")
+
+    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode()
+    sent = service.users().messages().send(userId="me", body={"raw": raw}).execute()
+    return sent

--- a/src/providers/outlook_send.py
+++ b/src/providers/outlook_send.py
@@ -1,0 +1,54 @@
+from typing import List, Optional, Dict
+import requests
+
+
+def outlook_send_mail(
+    session: requests.Session,
+    from_addr: str,
+    to: List[str],
+    cc: List[str],
+    bcc: List[str],
+    subject: str,
+    body_text: str,
+    body_html: Optional[str] = None,
+) -> Dict:
+    """Send a message using the Microsoft Graph API.
+
+    Parameters
+    ----------
+    session:
+        Authenticated ``requests.Session`` object configured for the Graph API.
+    from_addr:
+        Address of the sender.
+    to, cc, bcc:
+        Recipient email lists. Empty lists are allowed.
+    subject:
+        Subject line of the email.
+    body_text:
+        Plain text body.
+    body_html:
+        Optional HTML body. When provided the message will be sent as HTML.
+
+    Returns
+    -------
+    dict
+        A dictionary with an ``ok`` flag. Consumers may extend this with more
+        information if needed.
+    """
+
+    body = {
+        "message": {
+            "subject": subject,
+            "body": {
+                "contentType": "HTML" if body_html else "Text",
+                "content": body_html if body_html else (body_text or ""),
+            },
+            "toRecipients": [{"emailAddress": {"address": a}} for a in to],
+            "ccRecipients": [{"emailAddress": {"address": a}} for a in cc] if cc else [],
+            "bccRecipients": [{"emailAddress": {"address": a}} for a in bcc] if bcc else [],
+        },
+        "saveToSentItems": True,
+    }
+    r = session.post("/me/sendMail", json=body, timeout=15)
+    r.raise_for_status()
+    return {"ok": True}

--- a/src/repo/__init__.py
+++ b/src/repo/__init__.py
@@ -1,0 +1,5 @@
+"""Database repository layer."""
+__all__ = [
+    "contacts_repo",
+    "email_repo",
+]

--- a/src/repo/contacts_repo.py
+++ b/src/repo/contacts_repo.py
@@ -1,0 +1,32 @@
+"""Repository helpers for contact lookups."""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from ..db import get_conn
+
+
+def search_contacts(q: str, limit: int = 10) -> List[Tuple[int, str, str]]:
+    """Search contacts by display name or email.
+
+    Parameters
+    ----------
+    q:
+        Search query string. A case-insensitive ``LIKE`` match is performed
+        against both the display name and email fields.
+    limit:
+        Maximum number of rows to return.
+    """
+    q_like = f"%{q.lower()}%"
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, display_name, email
+              FROM contacts
+             WHERE lower(email) LIKE %s OR lower(display_name) LIKE %s
+             ORDER BY frequency_score DESC, last_seen_at DESC NULLS LAST
+             LIMIT %s
+            """,
+            (q_like, q_like, limit),
+        )
+        return cur.fetchall()

--- a/src/repo/email_repo.py
+++ b/src/repo/email_repo.py
@@ -1,0 +1,73 @@
+"""Repository helpers for outbound email drafting and sending."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+from ..db import get_conn
+
+
+def create_outbound_draft(
+    provider: str,
+    from_email: str,
+    to: List[str],
+    cc: List[str],
+    bcc: List[str],
+    subject: str,
+    draft_text: str,
+    body_html: Optional[str],
+    thread_id: Optional[str] = None,
+) -> int:
+    """Insert a draft outbound message and return its internal id."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO email_messages (
+                provider, direction, provider_message_id, thread_id, from_email,
+                to_emails, cc_emails, bcc_emails, subject, body_plain, body_html,
+                status
+            ) VALUES (%s,'outbound', NULL, %s, %s,
+                      %s, %s, %s, %s, %s, %s, 'draft')
+            RETURNING id
+            """,
+            (
+                provider,
+                thread_id,
+                from_email,
+                to,
+                cc,
+                bcc,
+                subject,
+                draft_text,
+                body_html,
+            ),
+        )
+        return cur.fetchone()[0]
+
+
+def mark_outbound_sent(
+    email_id: int,
+    provider_message_id: str,
+    provider_thread_id: Optional[str] = None,
+) -> None:
+    """Mark a draft message as sent and update provider identifiers."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE email_messages
+               SET status='sent',
+                   provider_message_id=%s,
+                   last_action='send',
+                   last_accessed_at=NOW()
+             WHERE id=%s
+            """,
+            (provider_message_id, email_id),
+        )
+        if provider_thread_id:
+            cur.execute(
+                """
+                INSERT INTO email_threads (provider, provider_thread_id)
+                VALUES ((SELECT provider FROM email_messages WHERE id=%s), %s)
+                ON CONFLICT DO NOTHING
+                """,
+                (email_id, provider_thread_id),
+            )


### PR DESCRIPTION
## Summary
- add Gmail and Outlook send helpers to build RFC-2822 messages and call provider APIs
- provide repository layer with contact search and outbound email draft tracking
- document compose-email feature and expose project as `pa_v2` package for compatibility

## Testing
- `pytest -q` *(fails: Tunnel connection failed: 403 Forbidden; import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b076cbae988324b5b52c724bef642b